### PR TITLE
Add an option for disabling filetypes

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,10 +67,19 @@ require("autoclose").setup({})
 
 You can pass your config table into the `setup()` function.
 
+### Keys
+
+The available options in `keys`:
+- `close`: If set to true, pressing the character will insert both the opening and closing characters, and place the cursor in between them.
+- `escape`: If set to true, pressing the character again will escape it instead of inserting a closing character.
+- `pair`: The string that represents the pair of opening and closing characters. This should be a two-character string, with the opening character first and the closing character second.
+
 Example: Add a `$$` pair.
 ```Lua
 require("autoclose").setup({
-  ["$"] = { escape = true, close = true, pair = "$$"},
+   keys = {
+      ['$'] = { escape = true, close = true, pair = "$$"},
+   },
 })
 ```
 
@@ -83,22 +92,40 @@ require("autoclose").setup({
 })
 ```
 
+### Options
+
+The available options in `options`:
+- `disabled_filetypes`: The plugin will be disabled under the filetypes in this table.
+
+Example: Disable the plugin in text and markdown file.
+```Lua
+require("autoclose").setup({
+   options = {
+      disabled_filetypes = { "text", "markdown" },
+   },
+})
+```
+
 Here is the default config:
 ```Lua
 local config = {
-   ["("] = { escape = false, close = true, pair = "()"},
-   ["["] = { escape = false, close = true, pair = "[]"},
-   ["{"] = { escape = false, close = true, pair = "{}"},
+   keys = {
+      ["("] = { escape = false, close = true, pair = "()"},
+      ["["] = { escape = false, close = true, pair = "[]"},
+      ["{"] = { escape = false, close = true, pair = "{}"},
 
-   [">"] = { escape = true, close = false, pair = "<>"},
-   [")"] = { escape = true, close = false, pair = "()"},
-   ["]"] = { escape = true, close = false, pair = "[]"},
-   ["}"] = { escape = true, close = false, pair = "{}"},
+      [">"] = { escape = true, close = false, pair = "<>"},
+      [")"] = { escape = true, close = false, pair = "()"},
+      ["]"] = { escape = true, close = false, pair = "[]"},
+      ["}"] = { escape = true, close = false, pair = "{}"},
 
-   ['"'] = { escape = true, close = true, pair = '""'},
-   ["'"] = { escape = true, close = true, pair = "''"},
-   ["`"] = { escape = true, close = true, pair = "``"},
-
-   disabled_filetypes = { 'markdown' },
+      ['"'] = { escape = true, close = true, pair = '""'},
+      ["'"] = { escape = true, close = true, pair = "''"},
+      ["`"] = { escape = true, close = true, pair = "``"},
+   },
+   options = {
+      disabled_filetypes = { "text" },
+   },
 }
 ```
+

--- a/README.md
+++ b/README.md
@@ -98,5 +98,7 @@ local config = {
    ['"'] = { escape = true, close = true, pair = '""'},
    ["'"] = { escape = true, close = true, pair = "''"},
    ["`"] = { escape = true, close = true, pair = "``"},
+
+   disabled_filetypes = { 'markdown' },
 }
 ```

--- a/lua/autoclose.lua
+++ b/lua/autoclose.lua
@@ -1,24 +1,26 @@
 local autoclose = {}
 
--- TODO: use ["()"] as key
 local config = {
-   ["("] = { escape = false, close = true, pair = "()"},
-   ["["] = { escape = false, close = true, pair = "[]"},
-   ["{"] = { escape = false, close = true, pair = "{}"},
+   keys = {
+      ["("] = { escape = false, close = true, pair = "()"},
+      ["["] = { escape = false, close = true, pair = "[]"},
+      ["{"] = { escape = false, close = true, pair = "{}"},
 
-   [">"] = { escape = true, close = false, pair = "<>"},
-   [")"] = { escape = true, close = false, pair = "()"},
-   ["]"] = { escape = true, close = false, pair = "[]"},
-   ["}"] = { escape = true, close = false, pair = "{}"},
+      [">"] = { escape = true, close = false, pair = "<>"},
+      [")"] = { escape = true, close = false, pair = "()"},
+      ["]"] = { escape = true, close = false, pair = "[]"},
+      ["}"] = { escape = true, close = false, pair = "{}"},
 
-   ['"'] = { escape = true, close = true, pair = '""'},
-   ["'"] = { escape = true, close = true, pair = "''"},
-   ["`"] = { escape = true, close = true, pair = "``"},
+      ['"'] = { escape = true, close = true, pair = '""'},
+      ["'"] = { escape = true, close = true, pair = "''"},
+      ["`"] = { escape = true, close = true, pair = "``"},
 
-   ["<BS>"] = {},
-   ["<CR>"] = {},
-
-   disabled_filetypes = { "markdown", "TelescopePrompt" },
+      ["<BS>"] = {},
+      ["<CR>"] = {},
+   },
+   options = {
+      disabled_filetypes = { "text" },
+   },
 }
 
 local function get_pair()
@@ -30,23 +32,18 @@ local function get_pair()
 end
 
 local function is_pair(pair)
-   for opt, info in pairs(config) do
-      if opt ~= "disabled_filetypes" then
-         if pair == info.pair then
-            return true
-         end
+   for _, info in pairs(config.keys) do
+      if pair == info.pair then
+         return true
       end
    end
    return false
 end
 
 local function is_disabled()
-   local bo = vim.bo
-   -- If the buffer is read-only, this plugin should be disabled
-   if bo[vim.api.nvim_win_get_buf(0)].readonly == true then return true end
-   local current_filetype = bo.filetype
-   for _, value in pairs(config.disabled_filetypes) do
-      if value == current_filetype then
+   local current_filetype = vim.api.nvim_buf_get_option(0, "filetype")
+   for _, filetype in pairs(config.options.disabled_filetypes) do
+      if filetype == current_filetype then
          return true
       end
    end
@@ -71,10 +68,19 @@ local function handler(key, info)
 end
 
 function autoclose.setup(user_config)
-   for key, info in pairs(user_config) do
-      config[key] = info
+   if user_config.keys ~= nil then
+      for key, info in pairs(user_config.keys) do
+         config.keys[key] = info
+      end
    end
-   for key, info in pairs(config) do
+
+   if user_config.options ~= nil then
+      for key, info in pairs(user_config.options) do
+         config.options[key] = info
+      end
+   end
+
+   for key, info in pairs(config.keys) do
       vim.keymap.set("i", key, function() return handler(key, info) end,
          { noremap = true, expr = true })
    end

--- a/lua/autoclose.lua
+++ b/lua/autoclose.lua
@@ -17,6 +17,8 @@ local config = {
 
    ["<BS>"] = {},
    ["<CR>"] = {},
+
+   disabled_filetypes = { 'markdown' },
 }
 
 local function get_pair()
@@ -57,9 +59,21 @@ function autoclose.setup(user_config)
       config[key] = info
    end
 
-   for key, info in pairs(config) do
-      vim.keymap.set("i", key, function() return handler(key, info) end,
-         { noremap = true, expr = true })
+   local function should_disable_plugin()
+     local current_filetype = vim.bo.filetype
+     for _, disabled_ft in pairs(config.disabled_filetypes) do
+       if (disabled_ft == current_filetype) then
+         return true
+       end
+     end
+     return false
+   end
+
+   if not should_disable_plugin() then
+     for key, info in pairs(config) do
+        vim.keymap.set("i", key, function() return handler(key, info) end,
+           { noremap = true, expr = true })
+     end
    end
 end
 

--- a/lua/autoclose.lua
+++ b/lua/autoclose.lua
@@ -70,9 +70,6 @@ local function handler(key, info)
    end
 end
 
--- TODO don't forget to make sure it follows the style guidelines
--- that the person in the PR set me to follow (3-space indents mainly)
-
 function autoclose.setup(user_config)
    for key, info in pairs(user_config) do
       config[key] = info

--- a/lua/autoclose.lua
+++ b/lua/autoclose.lua
@@ -75,10 +75,8 @@ function autoclose.setup(user_config)
       config[key] = info
    end
    for key, info in pairs(config) do
-      vim.keymap.set("i", key, function()
-         return handler(key, info)
-      end,
-      { noremap = true, expr = true })
+      vim.keymap.set("i", key, function() return handler(key, info) end,
+         { noremap = true, expr = true })
    end
 end
 


### PR DESCRIPTION
Adds a new config option: `disabled_filetypes`, which by default disables on markdown. Provides an answer for issue #7.

Apologies if something is wrong with this pull request, I haven't done one before.