### PR TITLE
Allow an empty user configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ use 'm4xshen/autoclose.nvim'
 
 2. Setup the plugin in your `init.lua`.
 ```Lua
-require("autoclose").setup({})
+require("autoclose").setup()
 ```
 
 ## 🔧 Configuration

--- a/lua/autoclose.lua
+++ b/lua/autoclose.lua
@@ -77,6 +77,8 @@ local function handler(key, info)
 end
 
 function autoclose.setup(user_config)
+   user_config = user_config or {}
+   
    if user_config.keys ~= nil then
       for key, info in pairs(user_config.keys) do
          config.keys[key] = info


### PR DESCRIPTION
This is a minor change that allows for a nil default user configuration, eg:

```lua
require("autoclose").setup()
```

...which is a convention a number of other vim plugins use:
- https://github.com/m-demare/hlargs.nvim#usage
- https://github.com/numToStr/Comment.nvim#-installation
- https://github.com/gen740/SmoothCursor.nvim#install