### PR TITLE
Avoid breaking abbreviations

### DIFF
--- a/lua/autoclose.lua
+++ b/lua/autoclose.lua
@@ -111,11 +111,7 @@ function autoclose.setup(user_config)
 
    for key, info in pairs(config.keys) do
       vim.keymap.set("i", key, function()
-         if key == " " then
-            return "<C-]>" .. handler(key, info)
-         else
-            return handler(key, info)
-         end
+         return (key == " " and "<C-]>" or "") .. handler(key, info)
       end, { noremap = true, expr = true })
    end
 end

--- a/lua/autoclose.lua
+++ b/lua/autoclose.lua
@@ -110,8 +110,13 @@ function autoclose.setup(user_config)
    end
 
    for key, info in pairs(config.keys) do
-      vim.keymap.set("i", key, function() return handler(key, info) end,
-         { noremap = true, expr = true })
+      vim.keymap.set("i", key, function()
+         if key == " " then
+            return "<C-]>" .. handler(key, info)
+         else
+            return handler(key, info)
+         end
+      end, { noremap = true, expr = true })
    end
 end
 


### PR DESCRIPTION
Mapping `<SPACE>` causes abbreviations to break. Therefore `<C-]>` is required.