### PR TITLE
Implements #30, disable specific keys per filetype

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,14 +173,6 @@ local config = {
       ['"'] = { escape = true, close = true, pair = '""', disabled_filetypes = {} },
       ["'"] = { escape = true, close = true, pair = "''", disabled_filetypes = {} },
       ["`"] = { escape = true, close = true, pair = "``", disabled_filetypes = {} },
-
-      [" "] = { escape = false, close = true, pair = "  ", disabled_filetypes = {} },
-
-      ["<BS>"] = {},
-      ["<C-H>"] = {},
-      ["<C-W>"] = {},
-      ["<CR>"] = {},
-      ["<S-CR>"] = {},
    },
    options = {
       disabled_filetypes = { "text" },
@@ -188,6 +180,5 @@ local config = {
       pair_spaces = false,
       auto_indent = true,
    },
-   disabled = false,
 }
 ```

--- a/README.md
+++ b/README.md
@@ -77,12 +77,13 @@ The available options in `keys`:
 - `close`: If set to true, pressing the character will insert both the opening and closing characters, and place the cursor in between them.
 - `escape`: If set to true, pressing the character again will escape it instead of inserting a closing character.
 - `pair`: The string that represents the pair of opening and closing characters. This should be a two-character string, with the opening character first and the closing character second.
+- `disabled_filetypes`: Table of filetypes where the specific key should not be autoclosed.
 
 Example: Add a `$$` pair.
 ```Lua
 require("autoclose").setup({
    keys = {
-      ["$"] = { escape = true, close = true, pair = "$$"},
+      ["$"] = { escape = true, close = true, pair = "$$", disabled_filetypes = {} },
    },
 })
 ```
@@ -93,7 +94,7 @@ Example: Remove the escape function of `>`.
 ```Lua
 require("autoclose").setup({
    keys = {
-      [">"] = { escape = false, close = false, pair = "<>"},
+      [">"] = { escape = false, close = false, pair = "<>", disabled_filetypes = {} },
    },
 })
 ```
@@ -160,18 +161,26 @@ import { | }
 ```Lua
 local config = {
    keys = {
-      ["("] = { escape = false, close = true, pair = "()"},
-      ["["] = { escape = false, close = true, pair = "[]"},
-      ["{"] = { escape = false, close = true, pair = "{}"},
+      ["("] = { escape = false, close = true, pair = "()", disabled_filetypes = {} },
+      ["["] = { escape = false, close = true, pair = "[]", disabled_filetypes = {} },
+      ["{"] = { escape = false, close = true, pair = "{}", disabled_filetypes = {} },
 
-      [">"] = { escape = true, close = false, pair = "<>"},
-      [")"] = { escape = true, close = false, pair = "()"},
-      ["]"] = { escape = true, close = false, pair = "[]"},
-      ["}"] = { escape = true, close = false, pair = "{}"},
+      [">"] = { escape = true, close = false, pair = "<>", disabled_filetypes = {} },
+      [")"] = { escape = true, close = false, pair = "()", disabled_filetypes = {} },
+      ["]"] = { escape = true, close = false, pair = "[]", disabled_filetypes = {} },
+      ["}"] = { escape = true, close = false, pair = "{}", disabled_filetypes = {} },
 
-      ['"'] = { escape = true, close = true, pair = '""'},
-      ["'"] = { escape = true, close = true, pair = "''"},
-      ["`"] = { escape = true, close = true, pair = "``"},
+      ['"'] = { escape = true, close = true, pair = '""', disabled_filetypes = {} },
+      ["'"] = { escape = true, close = true, pair = "''", disabled_filetypes = {} },
+      ["`"] = { escape = true, close = true, pair = "``", disabled_filetypes = {} },
+
+      [" "] = { escape = false, close = true, pair = "  ", disabled_filetypes = {} },
+
+      ["<BS>"] = {},
+      ["<C-H>"] = {},
+      ["<C-W>"] = {},
+      ["<CR>"] = {},
+      ["<S-CR>"] = {},
    },
    options = {
       disabled_filetypes = { "text" },
@@ -179,5 +188,6 @@ local config = {
       pair_spaces = false,
       auto_indent = true,
    },
+   disabled = false,
 }
 ```

--- a/lua/autoclose.lua
+++ b/lua/autoclose.lua
@@ -2,20 +2,20 @@ local autoclose = {}
 
 local config = {
    keys = {
-      ["("] = { escape = false, close = true, pair = "()" },
-      ["["] = { escape = false, close = true, pair = "[]" },
-      ["{"] = { escape = false, close = true, pair = "{}" },
+      ["("] = { escape = false, close = true, pair = "()", disabled_filetypes = {} },
+      ["["] = { escape = false, close = true, pair = "[]", disabled_filetypes = {} },
+      ["{"] = { escape = false, close = true, pair = "{}", disabled_filetypes = {} },
 
-      [">"] = { escape = true, close = false, pair = "<>" },
-      [")"] = { escape = true, close = false, pair = "()" },
-      ["]"] = { escape = true, close = false, pair = "[]" },
-      ["}"] = { escape = true, close = false, pair = "{}" },
+      [">"] = { escape = true, close = false, pair = "<>", disabled_filetypes = {} },
+      [")"] = { escape = true, close = false, pair = "()", disabled_filetypes = {} },
+      ["]"] = { escape = true, close = false, pair = "[]", disabled_filetypes = {} },
+      ["}"] = { escape = true, close = false, pair = "{}", disabled_filetypes = {} },
 
-      ['"'] = { escape = true, close = true, pair = '""' },
-      ["'"] = { escape = true, close = true, pair = "''" },
-      ["`"] = { escape = true, close = true, pair = "``" },
+      ['"'] = { escape = true, close = true, pair = '""', disabled_filetypes = {} },
+      ["'"] = { escape = true, close = true, pair = "''", disabled_filetypes = {} },
+      ["`"] = { escape = true, close = true, pair = "``", disabled_filetypes = {} },
 
-      [" "] = { escape = false, close = true, pair = "  " },
+      [" "] = { escape = false, close = true, pair = "  ", disabled_filetypes = {} },
 
       ["<BS>"] = {},
       ["<C-H>"] = {},
@@ -53,7 +53,7 @@ local function is_pair(pair)
    return false
 end
 
-local function is_disabled()
+local function is_disabled(info)
    if config.disabled then
       return true
    end
@@ -63,11 +63,20 @@ local function is_disabled()
          return true
       end
    end
+
+   -- Let's check if the disabled_filetypes key is in the info table
+   if info["disabled_filetypes"] ~= nil then
+      for _, filetype in pairs(info.disabled_filetypes) do
+         if filetype == current_filetype then
+            return true
+         end
+      end
+   end
    return false
 end
 
 local function handler(key, info)
-   if is_disabled() then
+   if is_disabled(info) then
       return key
    end
    local pair = get_pair()


### PR DESCRIPTION
The implementation adds a `disabled_filetypes` key to the info tables of each default key. Then in de `is_disabled` function the aditional parameter `info` is passed to be able to check if for the current filetype and key the autoclose should be disabled.
Aditionally I added a quick check to see if the disabled_filetypes key exists to prevent errors if the new key is not added by users in their personal configurations.