### PR TITLE
feat: added disabled_when config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ The available options in `keys`:
 - `disabled_filetypes`: Table of filetypes where the specific key should not be autoclosed.
 - `enabled_filetypes`: Only autoclose the key under these filetypes. This option takes precedence over `disabled_filetypes`.
 - `disable_command_mode`: If set to true, the character will be disabled in command-line mode.
+- `disabled_when`: Function returning true when pair should be disabled.
 
 Example: Add a `$$` pair.
 ```Lua

--- a/lua/autoclose.lua
+++ b/lua/autoclose.lua
@@ -64,6 +64,10 @@ local function is_pair(pair)
 end
 
 local function is_disabled(info)
+   if info.disabled_when and info.disabled_when() then
+      return true
+   end
+
    if config.disabled then
       return true
    end


### PR DESCRIPTION
Enables to create your own custom conditions by executing a function if it is present in the table.  The function should return true when the pair is disabled and nil or false when not.

I made this so that I could disable certain pairs when in comments with this snippet:
```lua
local function in_comment()
	if
		require("cmp.config.context").in_treesitter_capture("comment") == true
		or require("cmp.config.context").in_syntax_group("Comment")
	then
		return true
	else
		return false
	end
end
```